### PR TITLE
chore: use three color class

### DIFF
--- a/src/components/arc.ts
+++ b/src/components/arc.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as THREE from 'three';
 import { CubicBezierCurve3 } from 'three';
-import { hexToVec3 } from '../utils/threejs';
 import type { ArcConfig } from '../types/arc';
 import calculateArcControlPoints from '../utils/arc-controlpoints';
 import arcDefaults from '../defaults/arc-defaults';
@@ -29,8 +28,8 @@ export default class Arc {
       controlPoints.end,
     );
 
-    const vec3StartColor = hexToVec3(this.config.startColor!) ?? new THREE.Vector3(1.0, 0.0, 1.0);
-    const vec3EndColor = hexToVec3(this.config.endColor!) ?? new THREE.Vector3(1.0, 1.0, 0.0);
+    const vec3StartColor = new THREE.Color(this.config.startColor! ?? "#ff00fff");
+    const vec3EndColor = new THREE.Color(this.config.endColor! ?? "#ffff00");
 
     const geometry = new THREE.TubeBufferGeometry(curve, 44, this.config.radius!, 8);
     geometry.computeBoundingBox();
@@ -41,17 +40,17 @@ export default class Arc {
       uniforms: {
         startColor: {
           value: new THREE.Vector4(
-            vec3StartColor.x,
-            vec3StartColor.y,
-            vec3StartColor.z,
+            vec3StartColor.r,
+            vec3StartColor.g,
+            vec3StartColor.b,
             this.config.startColorOpacity!,
           ),
         },
         endColor: {
           value: new THREE.Vector4(
-            vec3EndColor.x,
-            vec3EndColor.y,
-            vec3EndColor.z,
+            vec3EndColor.r,
+            vec3EndColor.g,
+            vec3EndColor.b,
             this.config.endColorOpacity!,
           ),
         },

--- a/src/components/bar.ts
+++ b/src/components/bar.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import type { BarConfig } from '../types/bar';
-import { calculateVec3FromLatLon, hexToVec3 } from '../utils/threejs';
+import { calculateVec3FromLatLon } from '../utils/threejs';
 
 import barVertexShader from '../shaders/bar.vert.glsl';
 import barFragmentShader from '../shaders/bar.frag.glsl';
@@ -31,8 +31,8 @@ export default class Bar {
     );
     geometry.computeBoundingBox();
 
-    const vec3StartColor = hexToVec3(this.config.startColor!) ?? new THREE.Vector3(1.0, 0.0, 1.0);
-    const vec3EndColor = hexToVec3(this.config.endColor!) ?? new THREE.Vector3(1.0, 1.0, 0.0);
+    const vec3StartColor = new THREE.Color(this.config.startColor! ?? "#ff00ff");
+    const vec3EndColor = new THREE.Color(this.config.endColor! ?? "#ffff00");
 
     if (!geometry.boundingBox) { throw Error('Globe - size of bar is unknown'); }
 
@@ -40,18 +40,18 @@ export default class Bar {
       uniforms: {
         startColor: {
           value: new THREE.Vector4(
-            vec3StartColor.x,
-            vec3StartColor.y,
-            vec3StartColor.z,
-              this.config.startColorOpacity!,
+            vec3StartColor.r,
+            vec3StartColor.g,
+            vec3StartColor.b,
+            this.config.startColorOpacity!,
           ),
         },
         endColor: {
           value: new THREE.Vector4(
-            vec3EndColor.x,
-            vec3EndColor.y,
-            vec3EndColor.z,
-              this.config.endColorOpacity!,
+            vec3EndColor.r,
+            vec3EndColor.g,
+            vec3EndColor.b,
+            this.config.endColorOpacity!,
           ),
         },
         bboxMin: {

--- a/src/components/globe.ts
+++ b/src/components/globe.ts
@@ -3,7 +3,6 @@ import * as THREE from 'three';
 import { getImageData } from '../utils/image-data';
 import configureDotMatrix from '../utils/globe-dots';
 import type { GlobeConfig } from '../types/globe';
-import { hexToVec3 } from '../utils/threejs';
 
 import baseSphereVertexShader from '../shaders/baseSphere.vert.glsl';
 import baseSphereFragmentShader from '../shaders/baseSphere.frag.glsl';
@@ -30,10 +29,10 @@ export default class Globe {
     const material = new THREE.ShaderMaterial({
       uniforms: {
         colorDay: {
-          value: hexToVec3(this.config.baseSphere!.colorDay!),
+          value: new THREE.Color(this.config.baseSphere!.colorDay!),
         },
         colorNight: {
-          value: hexToVec3(this.config.baseSphere!.colorNight!),
+          value: new THREE.Color(this.config.baseSphere!.colorNight!),
         },
       },
       vertexShader: baseSphereVertexShader,
@@ -50,7 +49,7 @@ export default class Globe {
     const atmosphereGeometry = new THREE.IcosahedronGeometry(this.config.radius, 11);
     const atmosphereMaterial = new THREE.ShaderMaterial({
       uniforms: {
-        color: { value: hexToVec3(this.config.atmosphere!.color!) },
+        color: { value: new THREE.Color(this.config.atmosphere!.color!) },
         viewVector: { value: this.#camera.position },
       },
       // blending: THREE.AdditiveBlending,
@@ -79,7 +78,7 @@ export default class Globe {
           value: 5.0,
         },
         color: {
-          value: hexToVec3(this.config.dotSphere!.color!),
+          value: new THREE.Color(this.config.dotSphere!.color!),
         },
       },
       transparent: true,

--- a/src/components/marker.ts
+++ b/src/components/marker.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-import { calculateVec3FromLatLon, hexToVec3 } from '../utils/threejs';
+import { calculateVec3FromLatLon } from '../utils/threejs';
 import type { MarkerConfig } from '../types/marker';
 import markerDefaults from '../defaults/marker-defaults';
 
@@ -28,7 +28,7 @@ export default class Marker {
         borderInnerRadius: { value: this.config.borderInnerRadius },
         borderOuterRadius: { value: this.config.borderOuterRadius },
         time: { value: randMinMax(0, 10) },
-        ringColor: { value: hexToVec3(this.config.color) },
+        ringColor: { value: new THREE.Color(this.config.color) },
       },
       fragmentShader: markerFragmentShader,
       vertexShader: markerVertexShader,

--- a/src/utils/threejs.ts
+++ b/src/utils/threejs.ts
@@ -1,4 +1,4 @@
-import { Color, Vector3 } from 'three';
+import { Vector3 } from 'three';
 
 export const X_AXIS = new Vector3(1, 0, 0);
 export const Y_AXIS = new Vector3(0, 1, 0);
@@ -18,14 +18,4 @@ export const calculateVec3FromLatLon = (lat: number, lon: number, radius: number
   const z = Math.sin(phi) * Math.sin(theta) * rho;
 
   return new Vector3(x, y, z);
-};
-
-export const hexToVec3 = (hexString: string): Vector3 | null => {
-  if (/^#([0-9A-F]{3}){1,2}$/i.test(hexString)) {
-    const color = new Color(hexString);
-    const rgb = color.toArray().map((_color) => Math.round(_color * 1000) / 1000);
-    return new Vector3(rgb[0], rgb[1], rgb[2]);
-  }
-
-  throw Error('Invalid hex string added. Did you forget to add #?');
 };


### PR DESCRIPTION
We can get away with using `THREE.Color` where `hexToVec3` and `Vector3` are used, replacing the `x`, `y`, `z` with its `r`, `g`, `b` components. This also will allow the user to pass in all these forms: 

* `'#ffffff'` 
* `'white'`
* `'rgb(255, 255, 255)'`
* `'rgb(100%, 100%, 100%)'`
* `1, 1, 1`

See [`THREE.Color`](https://threejs.org/docs/index.html?q=color#api/en/math/Color) for methods and more.