### PR TITLE
feat: allow canvas container to be passed as string or HTMLCanvasElement

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -27,9 +27,7 @@
   </head>
 
   <body>
-    <div id="app">
-      <div id="globe-container"></div>
-    </div>
+    <canvas id="globe-container"></canvas>
     <script type="module" src="./index.ts"></script>
   </body>
 </html>

--- a/example/index.ts
+++ b/example/index.ts
@@ -3,12 +3,14 @@ import { GeoJSONType } from '../src/types/geojson';
 import Marker from '../src/components/marker';
 import Bar from '../src/components/bar';
 
-const container = 'globe-container';
+const container = document.querySelector("#globe-container") as HTMLCanvasElement;
 
 // Instantanous camera move from point A to point B.
 // const globe = new GlobeScene(container, { cameraAnimation: { enabled: false }});
+//
 // By default, animated camera move from point A to point B.
-const globe = new GlobeScene(container, {
+const globe = new GlobeScene({
+  container,
   cameraAnimation: {
     enabled: true,
     damping: 0.01,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chargetrip/globe",
   "description": "Interactive globe to render real-time data.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "source": "src/index.ts",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/src/defaults/globe-defaults.ts
+++ b/src/defaults/globe-defaults.ts
@@ -3,6 +3,7 @@ import type { GlobeConfig } from '../types/globe';
 const globeDefaults: GlobeConfig = {
   radius: 600,
   animates: true,
+  container: 'globe-container',
   cameraAnimation: {
     enabled: true,
     damping: 0.05,

--- a/src/types/globe.ts
+++ b/src/types/globe.ts
@@ -1,6 +1,7 @@
 export interface GlobeConfig {
   radius?: number,
   animates?: boolean,
+  container?: string | HTMLCanvasElement,
   cameraAnimation?: {
     enabled?: boolean,
     damping?: number,


### PR DESCRIPTION
This allows the user to pass the canvas as either an already instantiated `HTMLCanvasElement` or use a string pointing to the `canvas`.