### PR TITLE
Fix infinite camera lerp when tab (page) is not visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chargetrip/globe",
   "description": "Interactive globe to render real-time data.",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "source": "src/index.ts",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/src/components/scene.ts
+++ b/src/components/scene.ts
@@ -146,7 +146,10 @@ export default class GlobeScene {
 
     this.#atmosphere.material.uniforms.viewVector.value = this.#camera.position;
 
-    if (this.globeConfig.cameraAnimation.enabled) {
+    if (
+      this.globeConfig.cameraAnimation.enabled &&
+      document.visibilityState !== "hidden"
+    ) {
       const { damping, speed } = this.globeConfig.cameraAnimation;
       const step = speed * delta * damping;
 
@@ -155,11 +158,7 @@ export default class GlobeScene {
       }
 
       if (!this.camera.camera.position.equals(this.camera.targetPosition)) {
-        this.camera.camera.position
-          .lerp(this.camera.targetPosition, step)
-          // NOTE: Set a max the camera can zoom, as the threejs lerp function
-          // will continue on lerping if the tab is left unattended,
-          .max(new THREE.Vector3(0, 0, 1000));
+        this.camera.camera.position.lerp(this.camera.targetPosition, step);
       }
     } else {
       this.camera.pivot.quaternion.copy(this.camera.targetQuaternion);


### PR DESCRIPTION
Due to background page throttling, switching tabs would result in quirky behavior when lerping the camera along its `z` axis.

Using the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) we no longer lerp in the background and immediately move to the next location when the page is not visible.
