### PR TITLE
Fix Marker mesh clipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chargetrip/globe",
   "description": "Interactive globe to render real-time data.",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "source": "src/index.ts",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/src/components/marker.ts
+++ b/src/components/marker.ts
@@ -19,8 +19,6 @@ export default class Marker {
   }
 
   draw(): THREE.Mesh {
-    const targetVector = new THREE.Vector3(0, 0, 0);
-
     const geometry = new THREE.PlaneGeometry(this.config.size, this.config.size);
     const material = new THREE.ShaderMaterial({
       uniforms: {
@@ -33,7 +31,8 @@ export default class Marker {
       fragmentShader: markerFragmentShader,
       vertexShader: markerVertexShader,
       transparent: true,
-      side: THREE.BackSide,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
     });
 
     const position = calculateVec3FromLatLon(
@@ -46,7 +45,7 @@ export default class Marker {
 
     // Offset position to prevent shader intersection with globe dots
     mesh.position.copy(position).multiplyScalar(1.0025);
-    mesh.lookAt(targetVector);
+    mesh.lookAt(position.multiplyScalar(2));
 
     return mesh;
   }

--- a/src/components/scene.ts
+++ b/src/components/scene.ts
@@ -190,14 +190,13 @@ export default class GlobeScene {
   }
 
   addMarkers(markers: Marker | Marker[]): void {
-    let localMarkers = markers;
-    if (!Array.isArray(markers)) { localMarkers = [markers]; }
+    markers = Array.isArray(markers) ? markers : [markers];
 
-    (localMarkers as Marker[]).forEach((marker) => {
+    for (const marker of markers) {
       const mesh = marker.draw();
       this.#markerMeshes.push(mesh);
       this.#scene.add(mesh);
-    });
+    }
   }
 
   removeAllMarkers(): void {


### PR DESCRIPTION
This disables depth testing for the Marker mesh, allowing it to be overlaid over other Marker meshes.