### PR TITLE
Fix canvas not inheriting dimensions

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -9,8 +9,13 @@
     <style>
       html,
       body {
+        width: 100%;
+        height: 100%;
+      }
+
+      body {
         margin: 0;
-        padding: 0;
+
         background-color: #0c0c0f;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chargetrip/globe",
   "description": "Interactive globe to render real-time data.",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "source": "src/index.ts",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/src/components/scene.ts
+++ b/src/components/scene.ts
@@ -70,6 +70,7 @@ export default class GlobeScene {
     );
 
     window.addEventListener("resize", this.handleResize);
+    this.handleResize();
 
     this.drawGlobe();
     this.init();
@@ -94,11 +95,16 @@ export default class GlobeScene {
     return container;
   }
 
-  private handleResize = (_: UIEvent): void => {
-    this.#renderer.setSize(window.innerWidth, window.innerHeight);
+  private handleResize = (): void => {
+    const canvas = this.#renderer.domElement;
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
 
-    this.#camera.aspect = window.innerWidth / window.innerHeight;
-    this.#camera.updateProjectionMatrix();
+    if (canvas.width !== width || canvas.height !== height) {
+      this.#renderer.setSize(width, height, false);
+      this.#camera.aspect = width / height;
+      this.#camera.updateProjectionMatrix();
+    }
   }
 
   private init(): void {
@@ -113,10 +119,6 @@ export default class GlobeScene {
     this.#camera.updateProjectionMatrix();
 
     this.#renderer.setPixelRatio(window.devicePixelRatio);
-    this.#renderer.setSize(
-      this.container.clientWidth,
-      this.container.clientHeight
-    );
 
     this.camera.pivot.add(this.#camera);
     this.#scene.add(this.camera.pivot);


### PR DESCRIPTION
The renderer will now inherit the dimensions for the passed `<canvas>` element or its selector. 