### PR TITLE
Feat: add azimuth and polar camera offset

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -15,6 +15,7 @@ const globe = new GlobeScene({
     enabled: true,
     damping: 0.01,
     speed: 50.0,
+    offsetPolar: 22.5,
   },
 });
 
@@ -91,6 +92,7 @@ function randomInteger(min: number, max: number): number {
 
 setInterval(() => {
   const { lat, lng, location } = locations[randomInteger(0, locations.length)];
+  console.log("Moving towards:", location);
 
   globe.camera.lookAt(lat, lng, randomInteger(1000, 2000));
 }, 5000);

--- a/example/index.ts
+++ b/example/index.ts
@@ -91,8 +91,7 @@ function randomInteger(min: number, max: number): number {
 }
 
 setInterval(() => {
-  const { lat, lng, location } = locations[randomInteger(0, locations.length)];
-  console.log("Moving towards:", location);
+  const { lat, lng } = locations[randomInteger(0, locations.length)];
 
   globe.camera.lookAt(lat, lng, randomInteger(1000, 2000));
 }, 5000);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chargetrip/globe",
   "description": "Interactive globe to render real-time data.",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "source": "src/index.ts",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/src/controllers/camera.ts
+++ b/src/controllers/camera.ts
@@ -9,6 +9,8 @@ export default class GlobeCamera {
   camera: THREE.PerspectiveCamera;
   targetQuaternion: THREE.Quaternion;
   targetPosition: THREE.Vector3;
+  offsetAzimuth: number;
+  offsetPolar: number;
 
   #t: number;
   #speed: number;
@@ -40,8 +42,14 @@ export default class GlobeCamera {
     const rotationY = new THREE.Quaternion();
     const rotationX = new THREE.Quaternion();
 
-    rotationY.setFromAxisAngle(Y_AXIS, degreesToRadians(lng));
-    rotationX.setFromAxisAngle(X_AXIS, degreesToRadians(-lat));
+    rotationY.setFromAxisAngle(
+      Y_AXIS,
+      degreesToRadians(lng + this.cameraAnimation.offsetAzimuth)
+    );
+    rotationX.setFromAxisAngle(
+      X_AXIS,
+      degreesToRadians(-lat + this.cameraAnimation.offsetPolar)
+    );
 
     this.targetQuaternion.copy(rotationY.multiply(rotationX));
     this.targetPosition.z = alt;

--- a/src/defaults/globe-defaults.ts
+++ b/src/defaults/globe-defaults.ts
@@ -8,6 +8,8 @@ const globeDefaults: GlobeConfig = {
     enabled: true,
     damping: 0.05,
     speed: 50,
+    offsetAzimuth: 0,
+    offsetPolar: 0,
   },
   baseSphere: {
     colorDay: '#606263',

--- a/src/types/globe.ts
+++ b/src/types/globe.ts
@@ -6,6 +6,8 @@ export interface GlobeConfig {
     enabled?: boolean,
     damping?: number,
     speed?: number,
+    offsetAzimuth?: number,
+    offsetPolar?: number,
   },
   baseSphere?: {
     colorDay?: string,


### PR DESCRIPTION
This allows us to set a small azimuth or polar offset in degrees for the camera, as one might not want the camera to zoom straight on top of the target location, but look at it from an angle, e.g:

<img width="796" alt="Chargetrip globe zoomed in on Amsterdam" src="https://user-images.githubusercontent.com/12190184/148221514-d0be5405-32bc-4506-9dc9-87fa5a9ade9d.png">

